### PR TITLE
Solve Group Anagrams Using Categorizing by LetterCount

### DIFF
--- a/Templates/debug snippets
+++ b/Templates/debug snippets
@@ -1,0 +1,2 @@
+P.t("val = ", val);
+P.t("val = ", Arrays.toString(val));

--- a/src/main/java/com/lperthel/sequences/MergeIntervals.java
+++ b/src/main/java/com/lperthel/sequences/MergeIntervals.java
@@ -5,7 +5,7 @@ import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
 
-class Solution {
+class MergeIntervals {
  	List<int[]> merged = new LinkedList<>();   
 	public int[][] merge(int[][] intervals) {
  		   

--- a/src/main/java/com/lperthel/sequences/Solution.java
+++ b/src/main/java/com/lperthel/sequences/Solution.java
@@ -1,0 +1,34 @@
+package com.lperthel.sequences;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+class Solution {
+        public List<List<String>> groupAnagrams(String[] strs) {
+        	Map<String, List<String>> anagramGroups = new HashMap<>();
+        	List<List<String>> answer = new LinkedList<>();
+        	Arrays.stream(strs).forEach( word ->{
+        	int [] anagramKey = new int[26];
+        	word.chars().forEach(letter ->
+        	anagramKey[letter - 97] = 1
+        			);
+        	StringBuilder letterCount = new StringBuilder("");
+        	for(int i =0;i<anagramKey.length;i++) {
+        		letterCount.append(anagramKey[i]);
+        	}
+        	
+
+        	List<String> group = anagramGroups.get(letterCount.toString());
+        	if(group == null) {
+        		group = new LinkedList<>();
+        		anagramGroups.put(letterCount.toString(),group);
+        	}
+        	group.add(word);
+        });
+        	return answer;
+        }        
+    }
+ 

--- a/src/main/java/com/lperthel/sequences/Solution.java
+++ b/src/main/java/com/lperthel/sequences/Solution.java
@@ -10,25 +10,49 @@ class Solution {
         public List<List<String>> groupAnagrams(String[] strs) {
         	Map<String, List<String>> anagramGroups = new HashMap<>();
         	List<List<String>> answer = new LinkedList<>();
+        	
+        	P.t("strs =" , Arrays.toString(strs));;
         	Arrays.stream(strs).forEach( word ->{
         	int [] anagramKey = new int[26];
-        	word.chars().forEach(letter ->
-        	anagramKey[letter - 97] = 1
-        			);
+        	P.t("word= ", word);
+        	word.chars().forEach(letter ->{
+        		P.t("letter= ", letter);
+        		anagramKey[letter - 97]++;
+        		P.t("anagramKey= ", anagramKey);
+        	});
         	StringBuilder letterCount = new StringBuilder("");
         	for(int i =0;i<anagramKey.length;i++) {
         		letterCount.append(anagramKey[i]);
         	}
-        	
+        	P.t("letterCount= ", letterCount);        	
 
         	List<String> group = anagramGroups.get(letterCount.toString());
         	if(group == null) {
+        		P.t("No group found for group= ", letterCount, ". Creating Group");
         		group = new LinkedList<>();
         		anagramGroups.put(letterCount.toString(),group);
         	}
         	group.add(word);
+        	P.t("Updating anagramGroups. Group now = ", anagramGroups.get(letterCount.toString()));
         });
+        	P.t("answer= ", answer);
         	return answer;
-        }        
+        }
+        protected static class P{
+    		 public static void t(Object... args){
+    
+    			 for(Object elem:args) {		
+    		 		System.out.print(elem+ " ");
+    		 	}
+    		 	System.out.println();
+    		 }
+    		 public static void t(Object str, Object[]... args){
+    			 System.out.print(str);
+    			 for(Object elem:args) {		
+    		 		System.out.print(elem+ " ");
+    		 	}
+    		 	System.out.println();
+    		 }
+
+        }
     }
- 

--- a/src/main/java/com/lperthel/sequences/Solution.java
+++ b/src/main/java/com/lperthel/sequences/Solution.java
@@ -18,7 +18,8 @@ class Solution {
         	P.t("word= ", word);
         	word.chars().forEach(letter ->{
         		P.t("letter= ", letter);
-        		anagramKey[letter - 97]++;
+        		final int asciiOffset = 97;
+        		anagramKey[letter - asciiOffset ]++;
         		P.t("anagramKey= ", Arrays.toString(anagramKey));
         	});
         	StringBuilder letterCount = new StringBuilder("");

--- a/src/main/java/com/lperthel/sequences/Solution.java
+++ b/src/main/java/com/lperthel/sequences/Solution.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 class Solution {
         public List<List<String>> groupAnagrams(String[] strs) {
@@ -18,7 +19,7 @@ class Solution {
         	word.chars().forEach(letter ->{
         		P.t("letter= ", letter);
         		anagramKey[letter - 97]++;
-        		P.t("anagramKey= ", anagramKey);
+        		P.t("anagramKey= ", Arrays.toString(anagramKey));
         	});
         	StringBuilder letterCount = new StringBuilder("");
         	for(int i =0;i<anagramKey.length;i++) {
@@ -35,6 +36,8 @@ class Solution {
         	group.add(word);
         	P.t("Updating anagramGroups. Group now = ", anagramGroups.get(letterCount.toString()));
         });
+        	
+        	answer = anagramGroups.values().stream().collect(Collectors.toList());		
         	P.t("answer= ", answer);
         	return answer;
         }

--- a/src/main/java/com/lperthel/sequences/Solution.java
+++ b/src/main/java/com/lperthel/sequences/Solution.java
@@ -1,47 +1,46 @@
 package com.lperthel.sequences;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 class Solution {
-        public List<List<String>> groupAnagrams(String[] strs) {
-        	Map<String, List<String>> anagramGroups = new HashMap<>();
+        private Map<String, List<String>> anagramGroups;
+		public List<List<String>> groupAnagrams(String[] strs) {
+        	anagramGroups = new HashMap<>();
         	List<List<String>> answer = new LinkedList<>();
         	
-        	P.t("strs =" , Arrays.toString(strs));;
+        	//P.t("strs =" , Arrays.toString(strs));;
         	Arrays.stream(strs).forEach( word ->{
         	int [] anagramKey = new int[26];
-        	P.t("word= ", word);
+        	//P.t("word= ", word);
         	word.chars().forEach(letter ->{
-        		P.t("letter= ", letter);
+        		//P.t("letter= ", letter);
         		final int asciiOffset = 97;
         		anagramKey[letter - asciiOffset ]++;
-        		P.t("anagramKey= ", Arrays.toString(anagramKey));
+        		//P.t("anagramKey= ", Arrays.toString(anagramKey));
         	});
-        	StringBuilder letterCount = new StringBuilder("");
-        	for(int i =0;i<anagramKey.length;i++) {
-        		letterCount.append(anagramKey[i]);
-        	}
-        	P.t("letterCount= ", letterCount);        	
+        	String letterCount = Arrays.toString(anagramKey);        	
+        	//P.t("letterCount= ", letterCount);        	
 
-        	List<String> group = anagramGroups.get(letterCount.toString());
-        	if(group == null) {
-        		P.t("No group found for group= ", letterCount, ". Creating Group");
-        		group = new LinkedList<>();
-        		anagramGroups.put(letterCount.toString(),group);
-        	}
-        	group.add(word);
-        	P.t("Updating anagramGroups. Group now = ", anagramGroups.get(letterCount.toString()));
+        	addwordToAnagramGroups(word, letterCount);
         });
         	
-        	answer = anagramGroups.values().stream().collect(Collectors.toList());		
-        	P.t("answer= ", answer);
-        	return answer;
+        	return new ArrayList<>(anagramGroups.values());
         }
+		private void addwordToAnagramGroups(String word, String letterCount) {
+			List<String> group = anagramGroups.get(letterCount);
+        	if(group == null) {
+        		//P.t("No group found for group= ", letterCount, ". Creating Group");
+        		group = new LinkedList<>();
+        		anagramGroups.put(letterCount,group);
+        	}
+        	group.add(word);
+        	//P.t("Updating anagramGroups. Group now = ", anagramGroups.get(letterCount));
+		}
         protected static class P{
     		 public static void t(Object... args){
     

--- a/src/main/java/com/lperthel/util/List.java
+++ b/src/main/java/com/lperthel/util/List.java
@@ -1,5 +1,0 @@
-package com.lperthel.util;
-
-public class List {
-
-}

--- a/src/main/java/com/lperthel/util/Lists.java
+++ b/src/main/java/com/lperthel/util/Lists.java
@@ -1,0 +1,20 @@
+package com.lperthel.util;
+
+import java.util.List;
+
+public class Lists <T>{
+  public static <T> boolean deepContainsAll(List<List<T>> subjectList, List<List<T>> subList) {
+	
+		
+			for(List<T>l2: subList) {
+				boolean foundMatch = false;
+				for(List<T> l1:subjectList) {
+				if(l1.containsAll(l2))
+				foundMatch = true;
+		}
+			if(!foundMatch)
+				return false;
+	}
+	  return true;
+}
+}

--- a/src/test/java/com/lperthel/sequences/GroupAnagramstTest.java
+++ b/src/test/java/com/lperthel/sequences/GroupAnagramstTest.java
@@ -1,7 +1,5 @@
 package com.lperthel.sequences;
 
-import static org.junit.Assert.assertEquals;
-
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
@@ -28,7 +26,8 @@ expected= new LinkedList<>();
 	expected .add(Arrays.asList("nat","tan"));
 	expected .add(Arrays.asList("ate","eat","tea"));
 		actual = solution.groupAnagrams(anagrams);
-assertEquals(expected, actual); 
+		assert(expected.containsAll(actual));
 	}
+	
 
 }

--- a/src/test/java/com/lperthel/sequences/GroupAnagramstTest.java
+++ b/src/test/java/com/lperthel/sequences/GroupAnagramstTest.java
@@ -7,6 +7,8 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import com.lperthel.util.Lists;
+
 class GroupAnagramstTest {
 private Solution solution = new Solution();
 private List<List<String>> expected;
@@ -26,8 +28,26 @@ expected= new LinkedList<>();
 	expected .add(Arrays.asList("nat","tan"));
 	expected .add(Arrays.asList("ate","eat","tea"));
 		actual = solution.groupAnagrams(anagrams);
-		assert(expected.containsAll(actual));
+		assert(Lists.deepContainsAll(actual, expected));
+		assert(Lists.deepContainsAll(expected, actual));
 	}
 	
+	@Test
+	void 	ttestGivenEmptyStringArray_ExpectListOfListEmptyString() {
+		String[] anagrams = {""}; 
+	expected .add(Arrays.asList(""));
+		actual = solution.groupAnagrams(anagrams);
+		assert(Lists.deepContainsAll(actual, expected));
+		assert(Lists.deepContainsAll(expected, actual));
+	}
 
+	@Test
+	void 	TestGivenNonAnagramsWithIdenticalAnagramKeysExpectDifferentAnagramGroups() {
+		String[] anagrams = {"bdddddddddd", "bbbbbbbbbbc"}; 
+	expected .add(Arrays.asList("bdddddddddd"));
+	expected .add(Arrays.asList("bbbbbbbbbbc"));
+		actual = solution.groupAnagrams(anagrams);
+		assert(Lists.deepContainsAll(actual, expected));
+		assert(Lists.deepContainsAll(expected, actual));
+	}
 }

--- a/src/test/java/com/lperthel/sequences/GroupAnagramstTest.java
+++ b/src/test/java/com/lperthel/sequences/GroupAnagramstTest.java
@@ -1,0 +1,31 @@
+package com.lperthel.sequences;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class GroupAnagramstTest {
+private Solution solution = new Solution();
+private List<List<String>> expected;
+private List<List<String>> actual;
+
+	@BeforeEach
+	void setUp() throws Exception {
+expected= new LinkedList<>();
+		actual = null;
+		
+	}
+
+	@Test
+	void test_GivenGroupOfAnagrams_ExpectGroupedAnagrams() {
+		String[] anagrams = { "eat","tea","tan","ate","nat","bat"};
+	actual = solution.groupAnagrams(anagrams);
+	boolean testEquality;
+	assertEquals(expected.size(), actual.size());
+	}
+
+}

--- a/src/test/java/com/lperthel/sequences/GroupAnagramstTest.java
+++ b/src/test/java/com/lperthel/sequences/GroupAnagramstTest.java
@@ -2,6 +2,7 @@ package com.lperthel.sequences;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -23,9 +24,11 @@ expected= new LinkedList<>();
 	@Test
 	void test_GivenGroupOfAnagrams_ExpectGroupedAnagrams() {
 		String[] anagrams = { "eat","tea","tan","ate","nat","bat"};
-	actual = solution.groupAnagrams(anagrams);
-	boolean testEquality;
-	assertEquals(expected.size(), actual.size());
+	expected .add(Arrays.asList("bat"));
+	expected .add(Arrays.asList("nat","tan"));
+	expected .add(Arrays.asList("ate","eat","tea"));
+		actual = solution.groupAnagrams(anagrams);
+assertEquals(expected, actual); 
 	}
 
 }

--- a/src/test/java/com/lperthel/sequences/MergeIntervalsTest.java
+++ b/src/test/java/com/lperthel/sequences/MergeIntervalsTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
 import com.lperthel.util.Printer;
 
 class MergeIntervalsTest {
-	private Solution solution = new Solution();
+	private MergeIntervals mergeIntervals = new MergeIntervals();
 private 	int[][]  actual;
 	@BeforeEach
 	public void X() {	
@@ -21,21 +21,21 @@ private 	int[][]  actual;
 	void test_Given4ElementArrayWith3Overlaps_Return3ElementArray() {
 final int[][] input = {{1,3},{2,6},{8,10},{15,18}};
 		int[][] expected  = {{1,6},{8,10},{15,18}};
-		actual = solution .merge(input);
+		actual = mergeIntervals .merge(input);
 		assertEquals(Arrays.deepToString(expected),Arrays.deepToString(actual));
 	}
 	@Test
 	void test_GivenSingleOverlap_ReturnSingleElementArray() {
 final int[][] input = {{1,4},{2,3}};
 		int[][] expected  = {{1,4,}};
-		actual = solution .merge(input);
+		actual = mergeIntervals .merge(input);
 		assertEquals(Arrays.deepToString(expected),Arrays.deepToString(actual));
 	}
 @Test
 void test_Given2elementArrayWithMinOverlap_ExpectSingleElementArray() {
 final int[][] input = {{1,4},{0,4}};
 	int[][] expected  = {{0,4}};
-	actual = solution .merge(input);
+	actual = mergeIntervals .merge(input);
 	assertEquals(Arrays.deepToString(expected),Arrays.deepToString(actual));
 }
 }

--- a/src/test/java/com/lperthel/util/ListsTest.java
+++ b/src/test/java/com/lperthel/util/ListsTest.java
@@ -1,0 +1,44 @@
+package com.lperthel.util;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ListsTest {
+	List<List<String>> mainList ;
+	List<List<String>> subList;
+	@BeforeEach
+	void setUp() throws Exception {
+		mainList = new ArrayList<>();
+		subList= new ArrayList<>();
+	}
+	@Test
+	void test_GivenSubLisExpectReverseDeepContainsAllFalse() {
+		mainList.add(Arrays.asList("bat"));
+		mainList.add(Arrays.asList("nat","tan"));
+		mainList.add(Arrays.asList("ate","eat","tea"));
+	subList.add(Arrays.asList("bat"));
+	subList.add(Arrays.asList("nat"));
+	subList.add(Arrays.asList("eat","tea","ate"));
+	assert(Lists.deepContainsAll(mainList, subList));
+	assertFalse(Lists.deepContainsAll(subList, mainList));
+	}
+	@Test
+	void Test_GivenListsWithIdenticalelementsExpectDeepContainsTrue() {
+		mainList .add(Arrays.asList("bat"));
+		mainList .add(Arrays.asList("nat","tan"));
+		mainList .add(Arrays.asList("ate","eat","tea"));
+	subList.add(Arrays.asList("bat"));
+	subList.add(Arrays.asList("tan","nat"));
+	subList.add(Arrays.asList("eat","tea","ate"));
+	assert(Lists.deepContainsAll(mainList, subList));
+	assert(Lists.deepContainsAll(subList, mainList));
+	}
+
+
+}


### PR DESCRIPTION
Solves the Group Anagram  problem by counting the occurrence of letters in each word and grouping words with the same letter count into entries in a hash map. For all non-trivial cases use the following algorithm:

1.	Create a stream of the input strings
2.	Count the occurrence of each letter in a 26 element array.
3.	Use the letter count to key into a hashmap.
4.	If no list of anagrams exists as a value, create the list
5.	Add the word to the list.
6.	Return the map’s value’s as a list
Final Results:
Runtime: 26ms(beats 19.91%)
Memory: 46.9mb (beats 37.98%).
Reflection:
It is unclear as to why the performance  is so poor. The implementation given is almost identical to leetcode’s official solution and better in some regards (use of streams and linked lists). Parallel streams appeared to hurt performance and were removed.1

References:
[Original Problem on Leet Code](https://leetcode.com/problems/group-anagrams/discussion/)
[Group Anagrams Solution on LeetCode](https://leetcode.com/problems/group-anagrams/solutions/127405/official-solution/)