### PR TITLE
Solves Longest palindrome

### DIFF
--- a/src/main/java/com/lperthel/datastructures/scratch.java
+++ b/src/main/java/com/lperthel/datastructures/scratch.java
@@ -1,5 +1,19 @@
 package com.lperthel.datastructures;
 
 public class scratch {
+	class Solution {
+	    public int longestPalindrome(String s) {
+	        int[] count = new int[128];
+	        for (char c: s.toCharArray())
+	            count[c]++;
 
+	        int ans = 0;
+	        for (int v: count) {
+	            ans += v / 2 * 2;
+	            if (ans % 2 == 0 && v % 2 == 1)
+	                ans++;
+	        }
+	        return ans;
+	    }
+	}
 }

--- a/src/main/java/com/lperthel/sequences/LongestPalindrome.java
+++ b/src/main/java/com/lperthel/sequences/LongestPalindrome.java
@@ -1,0 +1,32 @@
+package com.lperthel.sequences;
+
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class LongestPalindrome {
+
+	public int longestPalindrome(String s) {
+		Map<Character,Integer> map = new HashMap<>();
+		int occurance, maxLength = 0;
+		for(int i = 0;i<s.length();i++) {
+
+			if(map.containsKey(s.charAt(i)))
+				occurance = map.get(s.charAt(i))+1;
+			else occurance = 1;
+			map.put(s.charAt(i), occurance);
+		}
+		boolean hasOddValues = false;
+		for(int val:map.values()) {
+			if(val%2 == 0)
+				maxLength +=val;
+			else {
+				hasOddValues = true;
+				maxLength +=val -1;
+			}
+		}
+		if(hasOddValues)
+			maxLength++;
+		return maxLength ;
+	}
+}

--- a/src/main/java/com/lperthel/sequences/Solution.java
+++ b/src/main/java/com/lperthel/sequences/Solution.java
@@ -1,0 +1,9 @@
+package com.lperthel.sequences;
+
+public class Solution {
+	
+	    public int longestPalindrome(String s) {
+	        return 0;
+    
+	}
+}

--- a/src/main/java/com/lperthel/sequences/Solution.java
+++ b/src/main/java/com/lperthel/sequences/Solution.java
@@ -1,9 +1,32 @@
 package com.lperthel.sequences;
 
+
+import java.util.HashMap;
+import java.util.Map;
+
 public class Solution {
-	
-	    public int longestPalindrome(String s) {
-	        return 0;
-    
+
+	public int longestPalindrome(String s) {
+		Map<Character,Integer> map = new HashMap<>();
+		int occurance, maxLength = 0;
+		for(int i = 0;i<s.length();i++) {
+
+			if(map.containsKey(s.charAt(i)))
+				occurance = map.get(s.charAt(i))+1;
+			else occurance = 1;
+			map.put(s.charAt(i), occurance);
+		}
+		boolean hasOddValues = false;
+		for(int val:map.values()) {
+			if(val%2 == 0)
+				maxLength +=val;
+			else {
+				hasOddValues = true;
+				maxLength +=val -1;
+			}
+		}
+		if(hasOddValues)
+			maxLength++;
+		return maxLength ;
 	}
 }

--- a/src/test/java/com/lperthel/datastructures/MergeTwoSortedListsTest.java
+++ b/src/test/java/com/lperthel/datastructures/MergeTwoSortedListsTest.java
@@ -1,11 +1,8 @@
 package com.lperthel.datastructures;
 
-import static org.junit.jupiter.api.Assertions.*;
-
-import java.util.concurrent.TimeUnit;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
 
 class MergeTwoSortedListsTest {
 private MergeTwoLists solution = new MergeTwoLists();

--- a/src/test/java/com/lperthel/datastructures/MiddleOfTheLinkedListTest.java
+++ b/src/test/java/com/lperthel/datastructures/MiddleOfTheLinkedListTest.java
@@ -1,6 +1,6 @@
 package com.lperthel.datastructures;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
 
@@ -8,7 +8,6 @@ class MiddleOfTheLinkedListTest {
 private MiddleOfTheLinkedList solution = new MiddleOfTheLinkedList();
 	@Test
 	void test_GivenFiveElementList_ExpectMiddleElement() {
-		ListNode[] input1 = ListNode.generateList(1,2,4,5,6);
 		ListNode[] input = ListNode.generateList(1,2,3,4,5);
 String actual = ListNode.printList(solution.middleNode(input[0]));
 String expected =ListNode.printList(input[2]);
@@ -16,7 +15,6 @@ assertEquals(expected,actual);
 	}
 	@Test
 	void test_GivenSixElementList_ExpectMiddleElement() {
-		ListNode[] input1 = ListNode.generateList(1,2,4,5,6);
 		ListNode[] input = ListNode.generateList(1,2,3,4,5,6);
 String actual = ListNode.printList(solution.middleNode(input[0]));
 String expected =ListNode.printList(input[3]);

--- a/src/test/java/com/lperthel/sequences/LongestPalindromeTest.java
+++ b/src/test/java/com/lperthel/sequences/LongestPalindromeTest.java
@@ -8,8 +8,8 @@ class LongestPalindromeTest {
 	private Solution solution = new Solution();
 	@Test
 	void test() {
-		String input = "abccgggccdd";
-		int expected =9;
+		String input = "abccgggccddaa";
+		int expected =11;
 		int actual = solution.longestPalindrome(input);
 		assertEquals(expected,actual);
 	}

--- a/src/test/java/com/lperthel/sequences/LongestPalindromeTest.java
+++ b/src/test/java/com/lperthel/sequences/LongestPalindromeTest.java
@@ -1,0 +1,17 @@
+package com.lperthel.sequences;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class LongestPalindromeTest {
+	private Solution solution = new Solution();
+	@Test
+	void test() {
+		String input = "abccgggccdd";
+		int expected =9;
+		int actual = solution.longestPalindrome(input);
+		assertEquals(expected,actual);
+	}
+
+}

--- a/src/test/java/com/lperthel/sequences/LongestPalindromeTest.java
+++ b/src/test/java/com/lperthel/sequences/LongestPalindromeTest.java
@@ -5,7 +5,7 @@ import static org.junit.Assert.assertEquals;
 import org.junit.jupiter.api.Test;
 
 class LongestPalindromeTest {
-	private Solution solution = new Solution();
+	private LongestPalindrome solution = new LongestPalindrome();
 	@Test
 	void test() {
 		String input = "abccgggccddaa";


### PR DESCRIPTION
1.	Iterate through the word and hash the number of occurrences of each letter. 
2.	Sum all occurrences of even numbers of letters.
3.	If a letter has an odd number of occurrences, add to the sum the even number of occurrences.
4.	If  there were any letters with an odd number of occurrences, add 1 to the sum. This accounts for the fact that the middle letter of the palindrome can be from a letter pool with an odd number of occurrences.
5.	Return the sum.


[Original Problem On LeetCode](https://leetcode.com/problems/longest-palindrome/)