### PR TITLE
Min cost climbing stairs

### DIFF
--- a/src/main/java/com/lperthel/dynamicProgramming/ClimbingStairs.java
+++ b/src/main/java/com/lperthel/dynamicProgramming/ClimbingStairs.java
@@ -1,8 +1,7 @@
 package com.lperthel.dynamicProgramming;
-class Solution {
-	public int minCostClimbingStairs(int[] cost) {
-		return -1;
- /*int fx=-1, f1=1,f2=2;
+class ClimbingStairs {
+    public int climbStairs(int n) {
+ int fx=-1, f1=1,f2=2;
     	if(n ==1)
 	 return f1;
  else  if(n == 2)
@@ -12,6 +11,6 @@ class Solution {
 	 f1=f2;
 	 f2=fx;
  }
-     	return fx     ;*/
+     	return fx     ;
     }
 }

--- a/src/main/java/com/lperthel/dynamicProgramming/Solution.java
+++ b/src/main/java/com/lperthel/dynamicProgramming/Solution.java
@@ -1,17 +1,16 @@
 package com.lperthel.dynamicProgramming;
 class Solution {
 	public int minCostClimbingStairs(int[] cost) {
-		return -1;
- /*int fx=-1, f1=1,f2=2;
-    	if(n ==1)
-	 return f1;
- else  if(n == 2)
-	 return f2;
- for(int i = 3;i<=n;i++) {
-	 fx = f1+f2;
-	 f1=f2;
-	 f2=fx;
+ int fx=-1, f0=cost[0],f1=cost[1];
+ for(int i = 2;i<=cost.length;i++) {
+	 if(i<cost.length){
+	 fx = Math.min(f0, f1)+cost[i];
+	 f0=f1;
+	f1=fx;
+	 } else
+		 fx = Math.min(f0, f1);
+	 
  }
-     	return fx     ;*/
+     	return fx     ;
     }
 }

--- a/src/test/java/com/lperthel/dynamicProgramming/ClimbingStairsTest.java
+++ b/src/test/java/com/lperthel/dynamicProgramming/ClimbingStairsTest.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
 class ClimbingStairsTest {
-	private Solution solution= new Solution();
+	private ClimbingStairs solution= new ClimbingStairs();
 	@Test
 	void test_Given5Stairs_Expect8Ways() {
 		int n = 5;

--- a/src/test/java/com/lperthel/dynamicProgramming/MinCostClimbingStairsTest.java
+++ b/src/test/java/com/lperthel/dynamicProgramming/MinCostClimbingStairsTest.java
@@ -16,7 +16,7 @@ class MinCostClimbingStairsTest {
 	@Test
 	void test_Example2() {
 		int[] cost = {1,100,1,1,1,100,1,1,100,1};
-		int expected = 16;
+		int expected = 6;
 		int actual = solution.minCostClimbingStairs(cost);
 		assertEquals(expected,actual);
 	}

--- a/src/test/java/com/lperthel/dynamicProgramming/MinCostClimbingStairsTest.java
+++ b/src/test/java/com/lperthel/dynamicProgramming/MinCostClimbingStairsTest.java
@@ -1,0 +1,23 @@
+package com.lperthel.dynamicProgramming;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class MinCostClimbingStairsTest {
+	private Solution solution= new Solution();
+	@Test
+	void test_Example1() {
+		int[] cost = {10,15,20};
+		int expected = 15;
+		int actual = solution.minCostClimbingStairs(cost);
+		assertEquals(expected,actual);
+	}
+	@Test
+	void test_Example2() {
+		int[] cost = {1,100,1,1,1,100,1,1,100,1};
+		int expected = 16;
+		int actual = solution.minCostClimbingStairs(cost);
+		assertEquals(expected,actual);
+	}
+}


### PR DESCRIPTION
Solve the min cost climbing stairs

1.	Set the two base cases to the first and second step, respectively. 
2.	To climb one stair, take the minimum cost between the stair immediately before it and two steps before it and add it to the cost of the current stair.
3.	Continue  to  climb stairs this way until the last step is reached.
4.	Compare the accumulated cost of the last stair and the stair before it. whichever is lower is the min cost to get to the last stair.

[Original Problem on LeetCode](https://leetcode.com/problems/min-cost-climbing-stairs/)